### PR TITLE
Multiqubit gate kernel

### DIFF
--- a/src/qibotf/custom_operators/__init__.py
+++ b/src/qibotf/custom_operators/__init__.py
@@ -10,5 +10,6 @@ from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import apply_z_
 from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import apply_two_qubit_gate
 from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import apply_fsim
 from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import apply_swap
+from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import apply_multi_qubit_gate
 from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import collapse_state
 from qibotf.custom_operators.python.ops.qibo_tf_custom_operators import measure_frequencies

--- a/src/qibotf/custom_operators/cc/kernels/apply_gate.h
+++ b/src/qibotf/custom_operators/cc/kernels/apply_gate.h
@@ -112,6 +112,14 @@ struct ApplyFsimFunctor : BaseTwoQubitGateFunctor<Device, T> {};
 template <typename Device, typename T>
 struct ApplySwapFunctor : BaseTwoQubitGateFunctor<Device, T> {};
 
+template <typename Device, typename T>
+struct ApplyMultiQubitGateFunctor {
+  void operator()(const OpKernelContext* context, const Device& d, T* state,
+                  int nqubits, int ntargets, int ncontrols,
+                  const int32* qubits, const int32* targets,
+                  const T* gate = NULL) const;
+};
+
 template <typename Device, typename T, typename NormType>
 struct CollapseStateFunctor {
   void operator()(OpKernelContext* context, const Device& d, T* state,

--- a/src/qibotf/custom_operators/cc/ops/custom_ops.cc
+++ b/src/qibotf/custom_operators/cc/ops/custom_ops.cc
@@ -126,3 +126,16 @@ REGISTER_GATE1_NOMATRIX_OP("ApplyZ")
 REGISTER_GATE2_OP("ApplyTwoQubitGate")
 REGISTER_GATE2_OP("ApplyFsim")
 REGISTER_GATE2_NOMATRIX_OP("ApplySwap")
+
+
+// Register multi-qubit kernel
+REGISTER_OP("ApplyMultiQubitGate")      \
+    .Attr("T: {complex64, complex128}") \
+    .Input("state: T")                  \
+    .Input("gate: T")                   \
+    .Input("qubits: int32")             \
+    .Input("targets: int32")            \
+    .Attr("nqubits: int")               \
+    .Attr("omp_num_threads: int")       \
+    .Output("out: T")                   \
+    .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);

--- a/src/qibotf/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibotf/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -72,5 +72,9 @@ apply_fsim = custom_module.apply_fsim
 apply_swap = custom_module.apply_swap
 
 
+def apply_multi_qubit_gate(state, gate, qubits, targets, nqubits, threads):
+    targets = tf.cast(tuple(nqubits - t - 1 for t in targets[::-1]), dtype="int32")
+    return custom_module.apply_multi_qubit_gate(state, gate, qubits, targets, nqubits, threads)
+
 def collapse_state(state, qubits, result, nqubits, normalize, omp_num_threads):
     return custom_module.collapse_state(state, qubits, result, nqubits, normalize, omp_num_threads)

--- a/src/qibotf/tests/test_multiqubit.py
+++ b/src/qibotf/tests/test_multiqubit.py
@@ -1,0 +1,44 @@
+import pytest
+import numpy as np
+import qibo
+from qibotf import custom_operators as op
+
+
+_atol = 1e-6
+
+def qubits_tensor(nqubits, targets, controls=[]):
+    qubits = list(nqubits - np.array(controls) - 1)
+    qubits.extend(nqubits - np.array(targets) - 1)
+    qubits = sorted(qubits)
+    return qubits
+
+
+def random_complex(shape, dtype="complex128"):
+    return (np.random.random(shape) + 1j * np.random.random(shape)).astype(dtype)
+
+
+@pytest.mark.parametrize(("nqubits", "targets", "controls"),
+                         [(3, [0, 1, 2], []), (4, [2, 1, 3], []),
+                          (5, [0, 2, 3], []), (8, [2, 6, 3], []),
+                          (5, [0, 2, 3, 4], []),
+                          (8, [0, 4, 2, 5, 7], []),
+                          (4, [2, 1, 3], [0]), (5, [0, 2, 3], [1]),
+                          (8, [2, 6, 3], [4, 7]), (5, [0, 2, 3, 4], [1]),
+                          (8, [0, 4, 2, 5, 7], [1, 3]),
+                          (10, [0, 4, 2, 5, 9], [1, 3, 7, 8])
+                          ])
+@pytest.mark.parametrize("dtype", ["complex128", "complex64"])
+@pytest.mark.parametrize("threads", [1, 4])
+def test_apply_multiqubit_gate(nqubits, targets, controls, dtype, threads):
+    qibo.set_backend("numpy")
+    state = random_complex((2 ** nqubits,), dtype=dtype)
+    state = state / np.sqrt(np.sum(np.abs(state) ** 2))
+    rank = 2 ** len(targets)
+    matrix = random_complex((rank, rank), dtype=dtype)
+
+    gate = qibo.gates.Unitary(matrix, *targets).controlled_by(*controls)
+    target_state = gate(np.copy(state))
+
+    qubits = qubits_tensor(nqubits, targets, controls)
+    state = op.apply_multi_qubit_gate(state, matrix, qubits, targets, nqubits, threads)
+    np.testing.assert_allclose(state, target_state, atol=_atol)


### PR DESCRIPTION
Implements the multi-qubit gate kernel following the same approach as qiboteam/qibojit#20. Note that this is approach does not use hard-coded kernels like the numbers recently quoted in qiboteam/qibojit#21. Here is a comparison between qiskit, qibotf and the equivalent qibojit approach:

<details>
<summary>ntargets = 3</summary>

nqubits | dry run qiskit | dry run qibojit | dry run qibotf | simulation qiskit | simulation qibojit | simulation qibotf
-- | -- | -- | -- | -- | -- | --
18 | 0.01170 | 0.09237 | 0.02548 | 0.00877 | 0.00492 | 0.00220
19 | 0.01107 | 0.10673 | 0.02073 | 0.00896 | 0.00863 | 0.00332
20 | 0.01384 | 0.12086 | 0.02881 | 0.01084 | 0.01616 | 0.00551
21 | 0.01661 | 0.13333 | 0.03532 | 0.01539 | 0.03646 | 0.01061
22 | 0.02668 | 0.32840 | 0.04569 | 0.02167 | 0.07079 | 0.02004
23 | 0.04263 | 0.22616 | 0.07047 | 0.03651 | 0.13214 | 0.04807
24 | 0.07299 | 0.36263 | 0.13911 | 0.07878 | 0.25786 | 0.12135
25 | 0.25749 | 0.75801 | 0.31855 | 0.25448 | 0.64894 | 0.29809
26 | 0.52401 | 1.43052 | 0.61407 | 0.51918 | 1.31629 | 0.58884
27 | 1.06919 | 2.75555 | 1.23645 | 1.05559 | 2.66540 | 1.19978
28 | 2.17414 | 5.48926 | 2.45485 | 2.17352 | 5.39658 | 2.39124

</details>
<details>
<summary>ntargets = 4</summary>

nqubits | dry run qiskit | dry run qibojit | dry run qibotf | simulation qiskit | simulation qibojit | simulation qibotf
-- | -- | -- | -- | -- | -- | --
18 | 0.01113 | 0.09318 | 0.02461 | 0.00827 | 0.00351 | 0.00233
19 | 0.01362 | 0.12354 | 0.02625 | 0.00947 | 0.00576 | 0.00410
20 | 0.01412 | 0.12086 | 0.02959 | 0.01205 | 0.01019 | 0.00615
21 | 0.02010 | 0.13881 | 0.03338 | 0.01588 | 0.02433 | 0.01170
22 | 0.02638 | 0.16000 | 0.04650 | 0.02293 | 0.04351 | 0.02280
23 | 0.03989 | 0.19244 | 0.06461 | 0.03798 | 0.08345 | 0.05122
24 | 0.07945 | 0.24854 | 0.15402 | 0.08488 | 0.15977 | 0.12824
25 | 0.27159 | 0.56422 | 0.32953 | 0.26875 | 0.46265 | 0.31490
26 | 0.54857 | 1.05891 | 0.67942 | 0.54588 | 0.94523 | 0.61521
27 | 1.10179 | 2.00998 | 1.31648 | 1.09791 | 1.90891 | 1.20035
28 | 2.24510 | 4.00680 | 2.49491 | 2.23486 | 3.89577 | 2.57190

</details>
<details>
<summary>ntargets = 5</summary>

nqubits | dry run qiskit | dry run qibojit | dry run qibotf | simulation qiskit | simulation qibojit | simulation qibotf
-- | -- | -- | -- | -- | -- | --
18 | 0.01216 | 0.10136 | 0.02676 | 0.00906 | 0.00290 | 0.00287
19 | 0.01388 | 0.09904 | 0.02782 | 0.01059 | 0.00469 | 0.00469
20 | 0.01575 | 0.12272 | 0.02600 | 0.01340 | 0.00785 | 0.00811
21 | 0.02319 | 0.11513 | 0.04216 | 0.01995 | 0.03085 | 0.01640
22 | 0.03306 | 0.17759 | 0.05513 | 0.02863 | 0.06529 | 0.03223
23 | 0.05402 | 0.23232 | 0.08038 | 0.04218 | 0.12590 | 0.06909
24 | 0.09230 | 0.33078 | 0.18059 | 0.09153 | 0.23075 | 0.15765
25 | 0.29719 | 0.66001 | 0.40347 | 0.28825 | 0.55934 | 0.37394
26 | 0.57951 | 1.26562 | 0.78829 | 0.57988 | 1.15358 | 0.70694
27 | 1.19996 | 2.47430 | 1.54240 | 1.17397 | 2.39005 | 1.49037
28 | 2.39696 | 5.24014 | 2.85213 | 2.38110 | 5.11806 | 2.88867

</details>

The qibotf performance is still slightly worse than qiskit but is faster than the equivalent qibojit approach. @scarrazza, is there any case that C++ handles the nested loops used in this code better than jit?