### PR TITLE
Pinning keras version to 2.6.0

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,12 +54,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest
-        pip install -r requirements.txt
         git clone https://github.com/qiboteam/qibo
         cd qibo
         git checkout rmbackends
-        python setup.py develop
+        pip install .
         cd ..
+        pip install -r requirements.txt
         pip install qibotf --no-index --find-links ./dist/
         pytest --pyargs qibotf
   deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Runtime requirements for qibotf
 
 tensorflow>=2.2,<=2.6.1
+keras==2.6.0


### PR DESCRIPTION
The release of tf2.6.1/keras2.7.0 includes a bug with keras dependency, which instead of using 2.6.0 uses 2.7.0 and this raises issues on qibo actions (even those based on 2.6.0, see e.g. [this](https://github.com/qiboteam/qibo/runs/4105880356?check_suite_focus=true))