### PR TITLE
upgrading tf to 2.7.0

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here a compatibility matrix for the qibotf versions:
 
 | qibotf | ref. qibo | tensorflow                       | OS Hardware                             | CUDA |
 |--------|-----------|----------------------------------|-----------------------------------------|------|
-| 0.0.4  | >=0.1.7   | 2.6.2 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
+| 0.0.4  | >=0.1.7   | 2.7.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
 | 0.0.3  |   0.1.6   | 2.6.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
 | 0.0.2  |   0.1.6   | 2.5.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
 | 0.0.1  |   0.1.6   | 2.4.1 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.0 |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Runtime requirements for qibotf
 
-tensorflow>=2.2,<=2.6.2
+tensorflow>=2.2,<=2.7.0

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     install_requires=requirements,
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     long_description=long_description,
     long_description_content_type='text/markdown',
 )

--- a/src/qibotf/custom_operators/Makefile
+++ b/src/qibotf/custom_operators/Makefile
@@ -29,7 +29,7 @@ SOURCES = $(filter-out $(CUDASRC), $(SRCS))
 TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
-CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
+CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++14
 ifeq ($(UNAME_S),Linux)
 	CFLAGS += -fopenmp
 endif
@@ -38,7 +38,7 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
-CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
+CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++14 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 
 LDFLAGS = -shared ${TF_LFLAGS}
 ifeq ($(UNAME_S),Darwin)


### PR DESCRIPTION
Ok, they decided to release 2.7.0 in less than 1 day from 2.6.2.
This PR implements the required changes, however we are forced to remove python3.6 support.