### PR TITLE
tf2.8.0 and py3.10 support

### DIFF
--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -24,7 +24,7 @@ elif [ $PYTHON_VERSION == "3.8" ]; then
     PYBIN="/opt/python/cp38-cp38/bin"
 elif [ $PYTHON_VERSION == "3.9" ]; then
     PYBIN="/opt/python/cp39-cp39/bin"
-elif [ $PYTHON_VERSION == "3.10"]; then
+elif [ $PYTHON_VERSION == "3.10" ]; then
     PYBIN="/opt/python/cp310-cp310/bin"
 else
     echo "Unsupported Python version $PYTHON_VERSION"

--- a/.github/scripts/build-linux.sh
+++ b/.github/scripts/build-linux.sh
@@ -24,6 +24,8 @@ elif [ $PYTHON_VERSION == "3.8" ]; then
     PYBIN="/opt/python/cp38-cp38/bin"
 elif [ $PYTHON_VERSION == "3.9" ]; then
     PYBIN="/opt/python/cp39-cp39/bin"
+elif [ $PYTHON_VERSION == "3.10"]; then
+    PYBIN="/opt/python/cp310-cp310/bin"
 else
     echo "Unsupported Python version $PYTHON_VERSION"
     exit 1

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
@@ -50,14 +50,6 @@ jobs:
       with:
         name: wheels
         path: dist
-    - name: Test wheels
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest
-        pip install qibo --pre
-        pip install -r requirements.txt
-        pip install qibotf --no-index --find-links ./dist/
-        pytest --pyargs qibotf
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Here a compatibility matrix for the qibotf versions:
 
 | qibotf | ref. qibo | tensorflow                       | OS Hardware                             | CUDA |
 |--------|-----------|----------------------------------|-----------------------------------------|------|
+| 0.0.5  | >=0.1.7   | 2.8.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
 | 0.0.4  | >=0.1.7   | 2.7.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
 | 0.0.3  |   0.1.6   | 2.6.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |
 | 0.0.2  |   0.1.6   | 2.5.0 for pip (>=2.2 for source) | linux cpu/gpu, mac cpu(pip)/gpu(source) | 11.2 |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Runtime requirements for qibotf
 
-tensorflow>=2.2,<=2.7.0
+tensorflow>=2.2,<=2.8.0


### PR DESCRIPTION
Adding tf2.8.0 and py3.10 support.
Before merging this PR we should release the current main so there is a version for tf2.7.0.